### PR TITLE
Fix IE 8 by using compatible date methods

### DIFF
--- a/raf.js
+++ b/raf.js
@@ -26,7 +26,7 @@
 	// heavily inspired from @darius gist mod: https://gist.github.com/paulirish/1579671#comment-837945
 	if (!requestAnimationFrame || !cancelAnimationFrame) {
 		requestAnimationFrame = function(callback) {
-			var now = Date.now(), nextTime = Math.max(lastTime + 16, now);
+			var now = new Date().getTime(), nextTime = Math.max(lastTime + 16, now);
 			return setTimeout(function() {
 				callback(lastTime = nextTime);
 			}, nextTime - now);


### PR DESCRIPTION
`Date.now()` is not supported in IE8, and the workaround is pretty easy.

I believe this is fairly important because this is a polyfill and having a polyfill not working on older browser is a bit of a headache...

Enjoy!
