### PR TITLE
Bower: Version declared in the json (0.0.3) is different than the resolved one

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
 	"name": "raf.js",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"main": "raf.js",
 	"ignore": [
 		"test.html"


### PR DESCRIPTION
When installing through bower:
mismatch Version declared in the json (0.0.3) is different than the resolved one (0.0.4)
